### PR TITLE
Fix pom.xml syntax

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
                   <includes>
                     <include>**/*.html</include>
                     <include>**/*.txt</include>
-                  </includes
+                  </includes>
                   <excludes>
                     <exclude>**/*.xml</exclude>
                   </excludes>


### PR DESCRIPTION
There is an XML syntax error in `pom.xml`, a missing closing `>`.