### PR TITLE
Made Xerces and Xalan optional

### DIFF
--- a/project2.xml
+++ b/project2.xml
@@ -50,12 +50,14 @@
       <artifactId>xercesImpl</artifactId>
       <version>2.8.0</version>
       <type>jar</type>
+      <optional>true</optional>
     </dependency>  
     <dependency>
       <groupId>xalan</groupId>
       <artifactId>xalan</artifactId>
       <version>2.7.2</version>
       <type>jar</type>
+      <optional>true</optional>
     </dependency>
   </dependencies>
   


### PR DESCRIPTION
This patch is implementing the idea in #162

I tested this with [CMLXOM](https://github.com/blueObelisk/cmlxom) that heavily depends on it (the data model is extending the XOM data model). CMLXOM with the optional Xerces/Xalan dependencies compiles fine and does not show any test fails.

So, my conclusion is that the question in #162 is "yes, it can be optional".