### PR TITLE
Update Jaxen to 2.0.1 for XPath improvements

### DIFF
--- a/website/history.html
+++ b/website/history.html
@@ -46,6 +46,8 @@ body {
 
 <h2>1.4.1</h2>
 
+<p>Updated Jaxen to 2.0.1 to resolve a couple of edge conditions in XPath processing:</p>
+
 <p><code>ParsingException.getMessage()</code> now includes the line and column number
 where the error occurred, if that information is available.</p>
 


### PR DESCRIPTION
Updated Jaxen to version 2.0.1 to fix XPath processing issues.