### PR TITLE
Guard against null locator in XOMHandler.inInternalSubset()

### DIFF
--- a/src/nu/xom/XOMHandler.java
+++ b/src/nu/xom/XOMHandler.java
@@ -563,6 +563,9 @@ class XOMHandler
         if (!usingCrimson) {
             return !inExternalSubset;
         }
+        if (locator == null) {
+            return !inExternalSubset;
+        }
         String currentURI = locator.getSystemId();
         if (currentURI == this.documentBaseURI) return true;
         if (currentURI == null) return false;


### PR DESCRIPTION
Fixes #445.

`inInternalSubset()` dereferences `locator.getSystemId()` when `usingCrimson` is true, but `locator` may be null because SAX parsers are not required to call `setDocumentLocator()`. This mirrors the existing null check already used in `startDocument()` (where `locator` is guarded before `getSystemId()`).

When `locator` is null we fall back to `!inExternalSubset`, consistent with the non-Crimson path.