### PR TITLE
Rely on compact strings for memory usage reduction

### DIFF
--- a/src/nu/xom/Text.java
+++ b/src/nu/xom/Text.java
@@ -20,8 +20,6 @@
 
 package nu.xom;
 
-import java.io.UnsupportedEncodingException;
-
 /**
  * <p>
  *   This class represents a run of text. 
@@ -39,13 +37,13 @@ import java.io.UnsupportedEncodingException;
  * </p>
  *
  * @author Elliotte Rusty Harold
- * @version 1.3.0
+ * @version 1.5.0
  *
  */
 public class Text extends Node {
 
     
-    private byte[] data;
+    private String value;
     
     
     /**
@@ -81,7 +79,7 @@ public class Text extends Node {
         // I'm relying here on the data array being immutable.
         // If this ever changes, e.g. by adding an append method,
         // this method needs to change too.
-        this.data = text.data;
+        this.value = text.value;
     }
 
     
@@ -91,14 +89,7 @@ public class Text extends Node {
     static Text build(String data) {
         
         Text result = new Text();
-        try {
-            result.data = data.getBytes("UTF8");   
-        }
-        catch (UnsupportedEncodingException ex) {
-            throw new RuntimeException(
-              "Bad VM! Does not support UTF-8"
-            );
-        } 
+        result.value = data;
         return result;
         
     }
@@ -131,14 +122,7 @@ public class Text extends Node {
         
         if (data == null) data = "";
         else Verifier.checkPCDATA(data);
-        try {
-            this.data = data.getBytes("UTF8");   
-        }
-        catch (UnsupportedEncodingException ex) {
-            throw new RuntimeException(
-              "Bad VM! Does not support UTF-8"
-            );
-        }
+        this.value = data;
         
     }
 
@@ -152,16 +136,7 @@ public class Text extends Node {
      * @return the content of the node
      */
     public final String getValue() {
-        
-        try {
-            return new String(data, "UTF8");
-        } 
-        catch (UnsupportedEncodingException ex) {
-            throw new RuntimeException(
-              "Bad VM! Does not support UTF-8"
-            );
-        }
-        
+        return value;
     }
 
     
@@ -466,7 +441,7 @@ public class Text extends Node {
 
 
     boolean isEmpty() {
-        return this.data.length == 0;
+        return this.value.isEmpty();
     }
 
     

--- a/website/history.html
+++ b/website/history.html
@@ -57,6 +57,11 @@ body {
   A single malicious document may fail to parse, but should not shut down the entire thread.
 </p>
 
+<p>
+The internal optimizations in Text have been flip flopped to improve performance in Java 9 and later
+at the expense of increased memory usage in Java 8 and earlier.
+</p>
+
 	
 <h2>1.4.6</h2>
 

--- a/website/history.html
+++ b/website/history.html
@@ -2204,7 +2204,7 @@ I also spent a lot of time improving the JavaDoc.
 <hr />
 <p>Copyright 2002-2005, 2009, 2013, 2018-2023, 2026 <a href="https://www.elharo.com/">Elliotte Rusty Harold</a><br />
 <a href="&#109;&#97;&#105;&#108;&#116;&#111;&#58;elharo%40ibiblio%2Eorg">elharo@ibiblio.org</a><br />
-Last Modified June 21, 2026
+Last Modified June 27, 2026
 </p>
 </div>
 <div id="Navbar">@SIDEBAR@</div>


### PR DESCRIPTION
Remove an optimization that no longer makes sense with compact strings.

This also removes an uncommon source of OutOfMemoryErrors and increases the maximum size of a XOM Text node in some cases.